### PR TITLE
fix(extension): changes `manifest.json` to v3

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,5 +1,5 @@
 {
-    "manifest_version": 2,
+    "manifest_version": 3,
     "name": "AWS Roles via Google SSO",
     "description": "Stay logged in to AWS console and get STS credentials for CLI access.",
     "version": "1.0.0",


### PR DESCRIPTION
#### What does this PR do

Changes `manifest.json` to version 3, because this manifest sets properties that are only available in the v3 of the manifest's schema (namely the `action.default_popup` property)