### PR TITLE
fix: Add iterator over logged in google accounts

### DIFF
--- a/extension/manifest-firefox.json
+++ b/extension/manifest-firefox.json
@@ -2,7 +2,7 @@
     "manifest_version": 2,
     "name": "AWS Roles via Google SSO",
     "description": "Stay logged in to AWS console and get STS credentials for CLI access.",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "browser_action": {
         "default_popup": "menu.html"
     },

--- a/package_firefox.sh
+++ b/package_firefox.sh
@@ -1,0 +1,9 @@
+#!/bin/env bash
+set -Eeuo pipefail
+
+(
+cd extension/
+mv manifest-firefox.json manifest.json
+zip -r -FS ../aws-roles-google-sso.zip *
+git checkout .
+)


### PR DESCRIPTION
This should allow multiple accounts to be logged in, as it will simply iterate over 10 indices until the SAML response is correctly returned.