### PR TITLE
feat(settings): Add account id/name mapping

### DIFF
--- a/extension/defaults.js
+++ b/extension/defaults.js
@@ -10,6 +10,8 @@ const defaults = {
 	platform: getPlatform(),
 	clientupdate: true,
 	idp_type: "google",
+	aws_account_mappings: "",
+	aws_account_mappings_parsed: {},
 };
 
 function getPlatform() {

--- a/extension/menu.css
+++ b/extension/menu.css
@@ -111,8 +111,25 @@ input:checked + .slider:before {
 
 .topbar {
     height: 50px;
-    width: 100%
+    width: 100%;
+    display: flex;
+    gap: 10px;
+    margin-bottom: 10px;
 }
+
+.topbar button {
+    padding: 5px 10px;
+    border-radius: 4px;
+    border: 1px solid #ccc;
+    background-color: #f5f5f5;
+    cursor: pointer;
+}
+
+.topbar button:hover {
+    background-color: #e0e0e0;
+}
+
+/* Reload UI button removed */
 
 .errorbar {
     position: fixed;
@@ -122,4 +139,26 @@ input:checked + .slider:before {
     background-color: red;
     z-index: 1;
     color: black;
+}
+
+.status-message {
+    padding: 5px;
+    margin-top: 5px;
+    border-radius: 3px;
+    text-align: center;
+    font-weight: bold;
+    display: none;
+}
+
+/* Style for the role input to accommodate longer text */
+.txtbox {
+    width: 300px;
+    height: 50px;
+    align-self: center;
+    justify-self: center;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-size: 14px; /* Smaller font size to fit more content */
+    padding: 5px 8px;
 }

--- a/extension/menu.css
+++ b/extension/menu.css
@@ -2,42 +2,45 @@ body{
     width: 500px;
 }
 
+h1 {
+    margin: 10px 0;
+    font-size: 20px;
+}
+
 .grid-container {
     display: grid;
-    grid-gap: 5px;
-    padding: 5px;
+    grid-gap: 2px;
+    padding: 3px;
     margin-right: 25px;
 }
 
 .grid-container > div {
-    font-size: 20px;
-    display:inline-grid;
+    font-size: 16px;
+    display: inline-grid;
     grid-template-columns: auto auto auto;
     align-items: center;
     justify-content: center;
 }
 
 .txtbox {
-    width:300px;
-    height: 50px;
+    width: 300px;
+    height: 32px;
     align-self: center;
     justify-self: center;
 }
 
 .btncls{
     /*display: block;*/
-    margin: 7px 10px;
+    margin: 3px 10px;
     align-self: center;
-
-
     justify-self: center;
 }
 
 .switch {
     position: relative;
     display: inline-block;
-    width: 36px;
-    height: 21px;
+    width: 32px;
+    height: 18px;
 }
 
 .switch input {
@@ -61,10 +64,10 @@ body{
 .slider:before {
     position: absolute;
     content: "";
-    height: 13px;
-    width: 13px;
-    left: 4px;
-    bottom: 4px;
+    height: 12px;
+    width: 12px;
+    left: 3px;
+    bottom: 3px;
     background-color: yellow;
     -webkit-transition: .4s;
     transition: .4s;
@@ -79,9 +82,9 @@ input:focus + .slider {
 }
 
 input:checked + .slider:before {
-    -webkit-transform: translateX(16px);
-    -ms-transform: translateX(16px);
-    transform: translateX(16px);
+    -webkit-transform: translateX(14px);
+    -ms-transform: translateX(14px);
+    transform: translateX(14px);
 }
 
 .slider.round {
@@ -95,14 +98,13 @@ input:checked + .slider:before {
 .clibtn {
     align-self: center;
     justify-self: center;
-    background-size: 26px;
+    background-size: 22px;
     visibility: hidden;
     background-image: url(/img/cli.png);
-    border: 1px solid #ddd;
     border: none;
     border-radius: 3px;
-    height: 26px;
-    width: 26px;
+    height: 22px;
+    width: 22px;
 }
 
 .clibtn:hover {
@@ -110,11 +112,9 @@ input:checked + .slider:before {
 }
 
 .topbar {
-    height: 50px;
+    height: 40px;
     width: 100%;
-    display: flex;
-    gap: 10px;
-    margin-bottom: 10px;
+    margin-bottom: 5px;
 }
 
 .topbar button {
@@ -153,12 +153,13 @@ input:checked + .slider:before {
 /* Style for the role input to accommodate longer text */
 .txtbox {
     width: 300px;
-    height: 50px;
+    height: 32px;
     align-self: center;
     justify-self: center;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
-    font-size: 14px; /* Smaller font size to fit more content */
-    padding: 5px 8px;
+    font-size: 13px; /* Smaller font size to fit more content */
+    padding: 2px 8px;
+    line-height: 1.2;
 }

--- a/extension/menu.js
+++ b/extension/menu.js
@@ -1,3 +1,5 @@
+// AWS Account ID to friendly name mapping will be loaded from storage
+
 const storage = getApi().storage.local;
 
 document.querySelector("#go-to-options").addEventListener("click", () => {
@@ -8,20 +10,83 @@ document.querySelector("#go-to-options").addEventListener("click", () => {
 	}
 });
 
-function handleTextboxes(props) {
-	//populate the textboxes from local storage
-	$("input[id^='role']").each(function () {
-		if ($(this).prop("readonly")) {
-			$(this).css("background-color", "#cccccc");
-		} else {
-			$(this).css("background-color", "#ffffff");
+// Add tooltip to settings button
+$("#go-to-options").prop("title", "Go to settings to configure AWS account names");
+
+// Format a role value with friendly name if available
+function applyFriendlyName(roleValue, accountMapping) {
+	// Check if this already has a friendly name format
+	const friendlyNamePattern = /^.+\((\d+)\)([:\/].*)/;
+	const friendlyMatch = roleValue.match(friendlyNamePattern);
+
+	if (friendlyMatch) {
+		// It already has a friendly name, keep it as is
+		return roleValue;
+	}
+
+	// Regular format: account_id:role/rolename
+	const parts = roleValue.split(":");
+	if (parts.length >= 2) {
+		const accountId = parts[0];
+		const friendlyName = accountMapping[accountId];
+
+		if (friendlyName) {
+			// Format display as "Account Name (account_id):role/rolename"
+			const remainingParts = roleValue.substring(accountId.length);
+			return `${friendlyName} (${accountId})${remainingParts}`;
 		}
+	}
+
+	// No friendly name available or unusual format
+	return roleValue;
+}
+
+function handleTextboxes(props) {
+	// Populate the textboxes from local storage
+	const awsAccountMapping = props.aws_account_mappings_parsed || {};
+	// Track updates to store all at once for better performance
+	let updates = {};
+
+	$("input[id^='role']").each(function () {
+		// Set background color based on readonly status
+		$(this).css("background-color", $(this).prop("readonly") ? "#cccccc" : "#ffffff");
+
 		const id = $(this).attr("id");
 		const currentRoleTxtBox = $(this);
+
 		if (typeof props[id] !== "undefined") {
-			currentRoleTxtBox.val(props[id]);
+			// Get the original value if it exists, otherwise use the stored value
+			const originalKey = `${id}_original`;
+			const roleValue = props[originalKey] || props[id];
+
+			// Check if this value already has a friendly name format
+			const hasFormattedName = roleValue.match(/^.+\((\d+)\)([:\/].*)$/);
+
+			if (hasFormattedName) {
+				// Already formatted, just use as is
+				currentRoleTxtBox.val(roleValue);
+			} else {
+				// Apply friendly name formatting
+				const formattedValue = applyFriendlyName(roleValue, awsAccountMapping);
+				currentRoleTxtBox.val(formattedValue);
+
+				// If we applied a friendly name, store the original for API calls
+				if (formattedValue !== roleValue) {
+					const match = formattedValue.match(/^.+\((\d+)\)([:\/].*)$/);
+					if (match) {
+						const originalValue = match[1] + match[2];
+						updates[`${id}_original`] = originalValue;
+						updates[id] = formattedValue;
+					}
+				}
+			}
 		}
 	});
+
+	// Save all updates at once for better performance
+	if (Object.keys(updates).length > 0) {
+		storage.set(updates);
+	}
 }
 
 function populateCheckboxesAndButtons(props) {
@@ -102,20 +167,34 @@ function getApi() {
 	}
 }
 async function main() {
-	//need to refresh it again..
+	// Get all stored data
 	const props = await storage.get(null);
+
 	if (props.roleCount === undefined) {
 		storage.set({ roleCount: 1 });
 		$("#go-to-options").click();
+		return;
 	}
 
-	buildMenu(props);
+	// Ensure we have the latest account mappings
+	storage.get(["aws_account_mappings_parsed"], (mappingData) => {
+		// Merge the latest mappings with the props
+		const updatedProps = {
+			...props,
+			aws_account_mappings_parsed: mappingData.aws_account_mappings_parsed || {}
+		};
+
+		buildMenu(updatedProps);
+	});
 
 	$("#clibtn").hover(function () {
 		alert($(this).prop("title"));
 	});
 
 	$('[id^="refresh-roles"]').click(() => {
+		// Show loading message
+		$("#msg").text("Refreshing roles...").css("backgroundColor", "#3498db").show();
+
 		storage.set({ autofill: 1 });
 		const port = chrome.runtime.connect({
 			name: "talk to background.js",
@@ -123,16 +202,21 @@ async function main() {
 		port.postMessage("role_refresh");
 		port.onMessage.addListener((msg) => {
 			if (msg === "roles_refreshed") {
-				location.reload();
+				$("#msg").text("Roles refreshed successfully!").css("backgroundColor", "#2ecc71").show().delay(1000).fadeOut();
+				setTimeout(() => {
+					location.reload();
+				}, 1000);
 			} else if (msg.includes("err")) {
 				storage.get(["last_msg_detail"], (result) => {
-					$("#msg").text(result.last_msg_detail);
+					$("#msg").text(result.last_msg_detail).css("backgroundColor", "#e74c3c").show();
 				});
 			} else {
 				console.log(`Service worker response:${msg}`);
 			}
 		});
 	});
+
+	// No reload UI handler needed - account mappings are applied automatically
 
 	//uncheck all checkboxes when modifying role ARNs
 	$("input[id^='role']").focus(() => {
@@ -147,11 +231,47 @@ async function main() {
 	//Save data to local storage automatically when not focusing on TxtBox
 	$("input[id^='role']").focusout(function () {
 		const roleName = $(this).attr("id");
-		const roleValue = $(this).val();
-		const obj = {
-			[roleName]: roleValue,
-		};
-		storage.set(obj);
+		const displayValue = $(this).val();
+		let roleValue = displayValue;
+
+		// Get account mappings from storage
+		storage.get(["aws_account_mappings_parsed"], (data) => {
+			const awsAccountMapping = data.aws_account_mappings_parsed || {};
+
+			// If the user entered a plain account ID, check if we have a friendly name for it
+			// Check for the regular format: account_id:role/rolename
+			if (roleValue.match(/^\d+:role\//)) {
+				const accountId = roleValue.split(":")[0];
+				const friendlyName = awsAccountMapping[accountId];
+
+				if (friendlyName) {
+					// Update the display to include the friendly name
+					const remainingParts = roleValue.substring(accountId.length);
+					const formattedValue = `${friendlyName} (${accountId})${remainingParts}`;
+					$(this).val(formattedValue);
+
+					// Store the original value for proper API calls
+					storage.set({ [`${roleName}_original`]: roleValue });
+
+					// Update the display value for storage
+					roleValue = formattedValue;
+				}
+			}
+			// If the user entered something with a friendly name pattern, extract the original format
+			else if (displayValue.match(/^.+\((\d+)\)(.*)$/)) {
+				const match = displayValue.match(/^.+\((\d+)\)(.*)$/);
+				if (match) {
+					// Store the original value in the format AWS expects
+					const originalValue = match[1] + match[2];
+					storage.set({ [`${roleName}_original`]: originalValue });
+				}
+			}
+
+			// Always store the display value
+			storage.set({
+				[roleName]: roleValue
+			});
+		});
 	});
 	//get the STS token from storage when clicking the CLI button.
 	$('[id^="sts_button"]').click(function () {
@@ -218,6 +338,20 @@ async function main() {
 			//set the roleTxtBox with the same data-index as the as checked.
 			$(`input[id^='role'][data-index=${dataIndex}]`).each(function () {
 				storage.set({ checked: $(this).attr("id") });
+
+				// Get the role value for further processing if needed
+				const displayValue = $(this).val();
+				// Extract the original account ID:role/rolename format if it includes a friendly name
+				let originalValue = displayValue;
+
+				// Check if the value has a friendly name format: "Name (account_id):role/rolename" or other variations
+				const match = displayValue.match(/^.+\((\d+)\)([:\/].*)$/);
+				if (match) {
+					// Reconstruct the original value with account ID only
+					originalValue = match[1] + match[2];
+					// Store the original value for use in other functions
+					storage.set({ [`${$(this).attr("id")}_original`]: originalValue });
+				}
 			});
 			//start background service functions
 			const port = chrome.runtime.connect({

--- a/extension/options.css
+++ b/extension/options.css
@@ -3,3 +3,22 @@
     width: 300px;
     margin: 10px;
 }
+
+.textareabox {
+    height: 150px;
+    width: 400px;
+    margin: 10px;
+    font-family: monospace;
+}
+
+.button {
+    margin: 10px;
+    padding: 5px 10px;
+}
+
+.status-message {
+    color: green;
+    margin: 10px;
+    font-weight: bold;
+    display: none;
+}

--- a/extension/options.html
+++ b/extension/options.html
@@ -25,6 +25,13 @@
                 <input type="text" id="google_spid" placeholder="Google Service Provider ID" class="txtbox" />
                 <label for=google_spid">Google Service Provider ID</label>
             </div>
+            <div class="item">
+                <h3>AWS Account Mappings</h3>
+                <p>Enter your AWS account IDs and friendly names (one per line, format: "accountId: Friendly Name")</p>
+                <textarea id="aws_account_mappings" placeholder="123456789012: Production&#10;234567890123: Development" class="textareabox"></textarea>
+                <button id="save_mappings" class="button">Save Account Mappings</button>
+                <div id="mapping_status" class="status-message"></div>
+            </div>
             <button>Save</button>
         </div>
     </body>

--- a/extension/options.js
+++ b/extension/options.js
@@ -18,6 +18,43 @@ $(".txtbox").focusout(function () {
 	storage.set(obj);
 });
 
+// Save textarea content to local storage
+$(".textareabox").focusout(function () {
+	const optionName = $(this).attr("id");
+	const optionValue = $(this).val();
+
+	// Parse account mappings into an object
+	if (optionName === "aws_account_mappings") {
+		const mappings = {};
+		const lines = optionValue.split("\n");
+
+		lines.forEach(line => {
+			// Skip empty lines
+			if (line.trim() === "") return;
+
+			// Expected format: "accountId: Friendly Name"
+			const parts = line.split(":");
+			if (parts.length >= 2) {
+				const accountId = parts[0].trim();
+				const friendlyName = parts.slice(1).join(":").trim();
+				if (accountId && friendlyName) {
+					mappings[accountId] = friendlyName;
+				}
+			}
+		});
+
+		// Save both the raw text and the parsed object
+		storage.set({
+			[optionName]: optionValue,
+			"aws_account_mappings_parsed": mappings
+		});
+	} else {
+		storage.set({
+			[optionName]: optionValue
+		});
+	}
+});
+
 //Save checkboxes values to local storage
 $(":checkbox").change(function () {
 	const optionName = $(this).attr("id");
@@ -58,6 +95,10 @@ function loadOptions() {
 			$(this).prop("checked", props[$(this).prop("id")]);
 		});
 	});
+
+	storage.get("aws_account_mappings", (props) => {
+		$("#aws_account_mappings").val(props.aws_account_mappings || "");
+	});
 }
 
 //display help information
@@ -86,6 +127,37 @@ $(".tablinks").click(function () {
 			$(this).css("display", "none");
 		}
 	});
+});
+
+// Handle Save Account Mappings button click
+$("#save_mappings").click(function() {
+    const optionValue = $("#aws_account_mappings").val();
+    const mappings = {};
+    const lines = optionValue.split("\n");
+
+    lines.forEach(line => {
+        // Skip empty lines
+        if (line.trim() === "") return;
+
+        // Expected format: "accountId: Friendly Name"
+        const parts = line.split(":");
+        if (parts.length >= 2) {
+            const accountId = parts[0].trim();
+            const friendlyName = parts.slice(1).join(":").trim();
+            if (accountId && friendlyName) {
+                mappings[accountId] = friendlyName;
+            }
+        }
+    });
+
+    // Save both the raw text and the parsed object
+    storage.set({
+        "aws_account_mappings": optionValue,
+        "aws_account_mappings_parsed": mappings
+    }, function() {
+        // Show success message
+        $("#mapping_status").text("Account mappings saved successfully!").fadeIn().delay(2000).fadeOut();
+    });
 });
 
 $(document).ready(loadOptions);


### PR DESCRIPTION
>[!WARNING]
> Mainly done by AI, review carefully

- Add an extra textbox for settings friendly name/id mapping as below
<img width="373" alt="Screenshot 2025-06-12 at 23 54 28" src="https://github.com/user-attachments/assets/effd9e73-40a9-46a8-bbf3-0eedcc89416a" />

and then will show the menu accordingly as

`name (account_id):role/rolename`
