### PR TITLE
fix(firefox): Allow calling AWS (sts) endpoints

### DIFF
--- a/extension/manifest-firefox.json
+++ b/extension/manifest-firefox.json
@@ -16,7 +16,8 @@
         "alarms",
         "*://*.google.com/*",
         "*://*.aws.amazon.com/*",
-        "http://localhost/*"
+        "http://localhost/*",
+        "*://*.amazonaws.com/*"
     ],
     "background": {
         "scripts": [


### PR DESCRIPTION
I don't understand how things were working without these perms in place.