### PR TITLE
chore(sts-function): Using URLSearchParams to build POST request body

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -219,10 +219,22 @@ function awsInit(props, port = null, jobType = "refresh") {
 }
 
 function fetchSts(roleArn, principalArn, samlResponse, props, port) {
-	const STSUrl = `${awsStsUrl}/?Version=2011-06-15&Action=AssumeRoleWithSAML&RoleArn=${roleArn}&PrincipalArn=${principalArn}&SAMLAssertion=${encodeURIComponent(samlResponse.trim())}&AUTHPARAMS&DurationSeconds=${props.session_duration}`;
-	fetch(STSUrl, {
-		method: "GET",
-		headers: requestHeaders,
+	const formBody = new URLSearchParams({
+		Version: "2011-06-15",
+		Action: "AssumeRoleWithSAML",
+		RoleArn: roleArn,
+		PrincipalArn: principalArn,
+		SAMLAssertion: samlResponse.trim(),
+		DurationSeconds: props.session_duration
+	}).toString();
+
+	fetch(awsStsUrl, {
+		method: "POST",
+		headers: {
+			"Content-Type": "application/x-www-form-urlencoded",
+			Accept: "*/*",
+		},
+		body: formBody,
 	})
 		.then((response) => response.text())
 		.then((data) => {


### PR DESCRIPTION
### Why

I was receiving a 400 when trying to retrieve credentials that is sent to the Always on service for updating the credential file. The issue seems to have been the way the request is being made. 

### Changes

- Change method from `GET` to `POST` with a properly formed request body
- Using `URLSearchParams` to build the request body
- Added `Content-Type` header as `application/x-www-form-urlencoded`
- Removed `&AUTHPARAMS&` from the request as it is not required

### Conclusion

The backend service now returns a 200 and successfully updates the AWSCLI credentials file. 

> [!WARNING]
> Not sure if other developers also experienced a similar issue, but this fixed the extension for me. 
> Used AI to help generate this, please review carefully

