### PR TITLE
chore: add account names

### DIFF
--- a/extension/menu.css
+++ b/extension/menu.css
@@ -123,3 +123,16 @@ input:checked + .slider:before {
     z-index: 1;
     color: black;
 }
+
+.account-header {
+    font-weight: 600;
+    font-size: 14px;
+    margin-top: 10px;
+    border-bottom: 1px solid #ddd;
+    color: #000;
+    background-color: #fff;
+}
+
+.account-header:first-child {
+    margin-top: 0;
+}

--- a/extension/menu.js
+++ b/extension/menu.js
@@ -48,47 +48,90 @@ function populateCheckboxesAndButtons(props) {
 	}
 }
 
+function getSortedAccountsWithRoles(props, accountNames) {
+	const roleCount = Number.parseInt(props.roleCount);
+	const rolesByAccount = Array.from({ length: roleCount }, (_, i) => ({
+		index: i,
+		role: props[`role${i}`]
+	}))
+		.filter(({ role }) => role)
+		.reduce((acc, { index, role }) => {
+			const accountId = role.split(":")[0];
+			return {
+				...acc,
+				[accountId]: [...(acc[accountId] || []), { index, role }]
+			};
+		}, {});
+	
+	const sortedAccounts = Object.keys(rolesByAccount).sort((a, b) => {
+		const nameA = (accountNames[a] || a).toLowerCase();
+		const nameB = (accountNames[b] || b).toLowerCase();
+		return nameA.localeCompare(nameB);
+	});
+	
+	return { rolesByAccount, sortedAccounts };
+}
+
 async function buildMenu(props) {
 	$("#grid").empty();
-	for (let i = 0; i < Number.parseInt(props.roleCount); i++) {
+	
+	const accountNames = props.accountNames || {};
+	const { rolesByAccount, sortedAccounts } = getSortedAccountsWithRoles(props, accountNames);
+	
+	for (const accountId of sortedAccounts) {
+		const headerText = accountNames[accountId] || `Account ${accountId}`;
+		
 		jQuery("<div>", {
-			id: `item${i}`,
-			class: `item${i}`,
+			class: "account-header",
+			text: headerText
 		}).appendTo("#grid");
+		
+		const sortedRoles = [...rolesByAccount[accountId]]
+			.sort((a, b) => a.role.localeCompare(b.role));
+		
+		for (const roleInfo of sortedRoles) {
+			const i = roleInfo.index;
+			
+			jQuery("<div>", {
+				id: `item${i}`,
+				class: `item${i}`,
+			}).appendTo("#grid");
 
-		const textboxProperties = {
-			type: "text",
-			value: "",
-			id: `role${i}`,
-			placeholder: "Role",
-			class: "txtbox",
-			"data-index": i,
-		};
-		textboxProperties.readonly = "readonly";
-		$(".txtbox").css("pointer-events", "none");
-		jQuery("<input>", textboxProperties).appendTo(`#item${i}`);
+			const textboxProperties = {
+				type: "text",
+				value: "",
+				id: `role${i}`,
+				placeholder: "Role",
+				class: "txtbox",
+				"data-index": i,
+			};
+			textboxProperties.readonly = "readonly";
+			$(".txtbox").css("pointer-events", "none");
+			jQuery("<input>", textboxProperties).appendTo(`#item${i}`);
 
-		jQuery("<label>", {
-			id: `label${i}`,
-			class: "switch btncls",
-		}).appendTo(`#item${i}`);
+			jQuery("<label>", {
+				id: `label${i}`,
+				class: "switch btncls",
+			}).appendTo(`#item${i}`);
 
-		jQuery("<input>", {
-			type: "checkbox",
-			id: `enable${i}`,
-			"data-index": i,
-		}).appendTo(`#label${i}`);
+			jQuery("<input>", {
+				type: "checkbox",
+				id: `enable${i}`,
+				"data-index": i,
+			}).appendTo(`#label${i}`);
 
-		jQuery("<span>", {
-			class: "slider round",
-		}).appendTo(`#label${i}`);
+			jQuery("<span>", {
+				class: "slider round",
+			}).appendTo(`#label${i}`);
 
-		jQuery("<button>", {
-			class: "button clibtn",
-			id: `sts_button${i}`,
-			"data-index": i,
-		}).appendTo(`#item${i}`);
+			jQuery("<button>", {
+				class: "button clibtn",
+				id: `sts_button${i}`,
+				"data-index": i,
+			}).appendTo(`#item${i}`);
+		}
 	}
+	
 	handleTextboxes(props);
 	populateCheckboxesAndButtons(props);
 }


### PR DESCRIPTION
This PR adds account names to the extension, so developers know what account is associated with the ID. The account name is retrieved from the SAML page, and I adjusted the design to be similar to the official AWS SAML page minus the removal of the full IAM role name.

TESTED ON CHROME.

<img width="541" height="656" alt="image" src="https://github.com/user-attachments/assets/36d02fab-c562-429a-adef-d5f61c576ca2" />

Original AWS SAML Page:

<img width="853" height="831" alt="image" src="https://github.com/user-attachments/assets/6ea1ce8f-16e8-45cb-a88d-7d9df96f15db" />
