### PR TITLE
Correct Mac Install Instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,6 @@ netstat
 ##### Installation
 1. Clone this repo
 2. `cd aosvc-python`
-3. `./install.sh`
+3. `./install_mac.sh`
 
 More info [here](/aosvc-python/README.md).

--- a/aosvc-python/README.md
+++ b/aosvc-python/README.md
@@ -35,6 +35,6 @@ cd aosvc-python
 ./install_mac.sh
 ```
 
-The script will install the python script in `~/.local/share/aosvc/bin/` and the service unit file in `~/Library/LaunchAgents. The service is loaded as a launchd service and will update the `default` profile in `~/.aws/credentials` for the installing user.
+The script will install the python script in `~/.local/share/aosvc/bin/` and the service unit file in `~/Library/LaunchAgents`. The service is loaded as a launchd service and will update the `default` profile in `~/.aws/credentials` for the installing user.
 
 There's also an `uninstall_mac.sh` for removal.


### PR DESCRIPTION
This PR aims to resolve an important typo in the README regarding installing the extension + Updater for Mac. Previously, the README stated to run the normal `install.sh`, but it needs to be `install_mac.sh` since `systemctl` is not supported on Mac. This also ensures that the base README matches the README in the `aosvc-python` directory.

I also noticed an issue with the inline code block in the `aosvc-python` README that made it awkward to read. I corrected it for aesthetic-sake: nothing more, nothing less. 

I propose we merge this PR to help save onboarding devs a bit of time and to align the two READMEs in the repo. 