### PR TITLE
fix(extension): vibecoding typeerror

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -27,12 +27,13 @@ const requestHeaders = {
 const storage = getApi().storage.local;
 
 function getApi() {
+  if (typeof browser !== "undefined") {
+    return browser;
+  }
   if (typeof chrome !== "undefined") {
-    if (typeof browser !== "undefined") {
-      return browser;
-    }
     return chrome;
   }
+  return undefined;
 }
 
 // Cookie injection state
@@ -40,31 +41,42 @@ let activeCookieStoreId = null;
 let pendingCookies = new Map(); // Map of URL -> cookie header string
 
 // Set up webRequest listener to inject cookies
-getApi().webRequest.onBeforeSendHeaders.addListener(
-  function (details) {
-    if (!activeCookieStoreId) {
+const api = getApi();
+const canInjectCookies =
+  api?.webRequest?.onBeforeSendHeaders &&
+  typeof api.webRequest.onBeforeSendHeaders.addListener === "function";
+
+if (canInjectCookies) {
+  api.webRequest.onBeforeSendHeaders.addListener(
+    function (details) {
+      if (!activeCookieStoreId) {
+        return { requestHeaders: details.requestHeaders };
+      }
+
+      const url = new URL(details.url);
+      const cookieKey = `${url.protocol}//${url.hostname}`;
+      const cookieHeader = pendingCookies.get(cookieKey);
+
+      if (cookieHeader) {
+        // Remove existing Cookie header if present
+        const headers = details.requestHeaders.filter(
+          (h) => h.name.toLowerCase() !== "cookie",
+        );
+        // Add our cookie header
+        headers.push({ name: "Cookie", value: cookieHeader });
+        return { requestHeaders: headers };
+      }
+
       return { requestHeaders: details.requestHeaders };
-    }
-
-    const url = new URL(details.url);
-    const cookieKey = `${url.protocol}//${url.hostname}`;
-    const cookieHeader = pendingCookies.get(cookieKey);
-
-    if (cookieHeader) {
-      // Remove existing Cookie header if present
-      const headers = details.requestHeaders.filter(
-        (h) => h.name.toLowerCase() !== "cookie",
-      );
-      // Add our cookie header
-      headers.push({ name: "Cookie", value: cookieHeader });
-      return { requestHeaders: headers };
-    }
-
-    return { requestHeaders: details.requestHeaders };
-  },
-  { urls: ["*://*.google.com/*"] },
-  ["blocking", "requestHeaders"],
-);
+    },
+    { urls: ["*://*.google.com/*"] },
+    ["blocking", "requestHeaders"],
+  );
+} else {
+  console.warn(
+    "webRequest.onBeforeSendHeaders is unavailable; container cookie injection is disabled.",
+  );
+}
 
 // Helper function to get cookies from a container and prepare them for injection
 async function prepareCookiesForUrl(url, cookieStoreId) {

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -18,6 +18,7 @@
     "host_permissions": [
         "https://accounts.google.com/*",
         "https://signin.aws.amazon.com/*",
+        "https://*.console.aws.amazon.com/*",
         "https://console.aws.amazon.com/*",
         "https://sts.amazonaws.com/*",
         "http://localhost/*"


### PR DESCRIPTION
I hit this error after updating to `Version 145.0.7632.160 (Official Build) (arm64)`

Uncaught TypeError: Cannot read properties of undefined (reading 'onBeforeSendHeaders')


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly defensive runtime checks, but the added `*.console.aws.amazon.com` host permission broadens the extension’s access scope and should be reviewed for least-privilege.
> 
> **Overview**
> Prevents a runtime `TypeError` by making `getApi()` prefer `browser` and returning `undefined` when no extension API is present, then **guarding cookie-injection setup** behind a capability check for `webRequest.onBeforeSendHeaders` (logging a warning instead of registering the listener).
> 
> Updates `manifest.json` host permissions to also allow `https://*.console.aws.amazon.com/*`, covering AWS console subdomains in addition to the existing `https://console.aws.amazon.com/*`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3d50e8d8cb4b601d1e678fce10d1d00f6e5a245a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->