### PR TITLE
fix(extension): adds `webRequest` and `webRequestBlocking` to the manifest's permissions - [sc-352241]

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,33 +1,30 @@
 {
-    "manifest_version": 3,
-    "name": "AWS Roles via Google SSO",
-    "description": "Stay logged in to AWS console and get STS credentials for CLI access.",
-    "version": "1.4.5",
-    "action": {
-        "default_popup": "menu.html"
-    },
-    "icons": {
-        "16": "img/icon16.png",
-        "48": "img/icon48.png",
-        "128": "img/icon128.png"
-    },
-    "permissions": [
-        "storage",
-        "alarms"
-    ],
-    "host_permissions": [
-        "https://accounts.google.com/*",
-        "https://signin.aws.amazon.com/*",
-        "https://console.aws.amazon.com/*",
-        "https://sts.amazonaws.com/*",
-        "http://localhost/*"
-    ],
-    "background": {
-        "service_worker": "background.js",
-        "type": "module"
-    },
-    "options_ui": {
-        "page": "options.html",
-        "open_in_tab": false
-    }
+  "manifest_version": 3,
+  "name": "AWS Roles via Google SSO",
+  "description": "Stay logged in to AWS console and get STS credentials for CLI access.",
+  "version": "1.4.5",
+  "action": {
+    "default_popup": "menu.html"
+  },
+  "icons": {
+    "16": "img/icon16.png",
+    "48": "img/icon48.png",
+    "128": "img/icon128.png"
+  },
+  "permissions": ["webRequest", "webRequestBlocking", "storage", "alarms"],
+  "host_permissions": [
+    "https://accounts.google.com/*",
+    "https://signin.aws.amazon.com/*",
+    "https://console.aws.amazon.com/*",
+    "https://sts.amazonaws.com/*",
+    "http://localhost/*"
+  ],
+  "background": {
+    "service_worker": "background.js",
+    "type": "module"
+  },
+  "options_ui": {
+    "page": "options.html",
+    "open_in_tab": false
+  }
 }

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -16,6 +16,7 @@
     "https://accounts.google.com/*",
     "https://signin.aws.amazon.com/*",
     "https://console.aws.amazon.com/*",
+    "https://*.console.aws.amazon.com/*",
     "https://sts.amazonaws.com/*",
     "http://localhost/*"
   ],


### PR DESCRIPTION
#### What does this PR do

Adds `webRequest` and `webRequestBlocking` to the manifest's permissions to fix the error (in Chrome):

```
Uncaught TypeError: Cannot read properties of undefined (reading 'onBeforeSendHeaders')
```

Relates to https://github.com/StuDocu/aws-roles-via-google-sso/pull/28


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds powerful network interception permissions (`webRequest*`), which increases extension privilege and may impact store review or security expectations, but the change itself is small and localized to the manifest.
> 
> **Overview**
> Fixes a Chrome runtime error by expanding `extension/manifest.json` permissions to include **`webRequest`** and **`webRequestBlocking`**, enabling the background `webRequest.onBeforeSendHeaders` hook used for request header/cookie injection.
> 
> No functional code changes beyond the manifest update; this primarily affects extension capability/privilege scope.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fea92670d9572248330c70cddab863f3dac80908. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->