### PR TITLE
feat: auto-update .env files with AWS credentials on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ The extension has been tested on Chrome and firefox.
 - Get temporary credentials for assumed role to use for CLI access.
 - Autofill all available AWS roles for Google Workspace account.
 - Automatically update local aws credentials file.
+- Automatically update specified .env files with AWS credentials (optional).
 
 ## Installation
 
@@ -40,6 +41,8 @@ Available directly in Add-ons for Firefox:
 First you will need to configure some properties in the Options menu. Each property has additional info that you can read to help you set it up properly.
 
 ![Options](img/opts.png)
+
+**Optional:** Add project directories in the "Paths to .env files" field (one per line). When credentials are refreshed, a `.env` file will be automatically created/updated in each directory with the new AWS credentials.
 
 When you are done, exit the Options menu.
 Now you can add your user's IAM role or roles or click the (A) button to initiate autofill.

--- a/aosvc-python/aosvc
+++ b/aosvc-python/aosvc
@@ -13,6 +13,87 @@ logger = logging.getLogger()
 
 AWS_CREDENTIALS_PATH = pathlib.Path(f'~/.aws/credentials').expanduser()
 
+ENV_VAR_NAMES = ['AWS_ACCESS_KEY_ID', 'AWS_SECRET_ACCESS_KEY', 'AWS_SESSION_TOKEN']
+
+
+def update_env_files(credentials):
+    """Update .env files with AWS credentials."""
+    env_file_paths = credentials.get('env_file_paths', [])
+    if not env_file_paths:
+        return
+
+    # Map credential keys to env var names
+    cred_mapping = {
+        'AWS_ACCESS_KEY_ID': credentials.get('AccessKeyId', ''),
+        'AWS_SECRET_ACCESS_KEY': credentials.get('SecretAccessKey', ''),
+        'AWS_SESSION_TOKEN': credentials.get('SessionToken', ''),
+    }
+
+    for env_path in env_file_paths:
+        try:
+            update_single_env_file(env_path, cred_mapping)
+            logger.info(f'Updated .env file: {env_path}')
+        except Exception as e:
+            logger.error(f'Error updating .env file {env_path}: {e}')
+            # Continue with other files even if one fails
+
+
+def update_single_env_file(env_path, env_vars):
+    """Update a single .env file with the given environment variables."""
+    path = pathlib.Path(env_path)
+
+    # Ensure directory exists
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    # Read existing content if file exists
+    lines = []
+    if path.exists():
+        with path.open('r') as f:
+            content = f.read()
+            lines = content.split('\n')
+
+    # Track which vars we've updated
+    updated_vars = set()
+    output_lines = []
+
+    # Process existing lines
+    for line in lines:
+        stripped = line.strip()
+
+        # Skip empty lines at the end for now
+        if not stripped:
+            continue
+
+        # Check if line starts with export prefix
+        prefix = ''
+        if stripped.startswith('export '):
+            prefix = 'export '
+            stripped = stripped[7:]  # Remove 'export '
+
+        # Check if this is one of our target variables
+        found = False
+        for var_name in ENV_VAR_NAMES:
+            if stripped.startswith(f'{var_name}='):
+                # Preserve the original prefix format
+                output_lines.append(f'{prefix}{var_name}={env_vars[var_name]}')
+                updated_vars.add(var_name)
+                found = True
+                break
+
+        if not found:
+            # Keep original line unchanged
+            output_lines.append(line)
+
+    # Add any variables that weren't in the file
+    for var_name in ENV_VAR_NAMES:
+        if var_name not in updated_vars:
+            output_lines.append(f'{var_name}={env_vars[var_name]}')
+
+    # Write back to file
+    output = '\n'.join(output_lines) + '\n'
+    with path.open('w') as f:
+        f.write(output)
+
 
 class MyRequestHandler(http.server.BaseHTTPRequestHandler):
     def _resp(self, status_code=http.HTTPStatus.OK, content=None):
@@ -54,6 +135,10 @@ class MyRequestHandler(http.server.BaseHTTPRequestHandler):
             logger.exception('Error parsing request!')
             return self._resp(http.HTTPStatus.BAD_REQUEST, f'{type(e).__name__}: {e}')
 
+        # Log received credentials data
+        env_paths = credentials.get('env_file_paths', [])
+        logger.info(f"Received env_file_paths: {env_paths}")
+
         try:
             # The default_section argument makes sure we have the section even if it's not in the file (or there is no file)
             ini = configparser.ConfigParser(default_section='default')
@@ -65,9 +150,22 @@ class MyRequestHandler(http.server.BaseHTTPRequestHandler):
             section['aws_session_expiration'] = credentials['Expiration']
             with AWS_CREDENTIALS_PATH.open('w') as f:
                 ini.write(f, space_around_delimiters=False)
+            logger.info(f"Updated AWS credentials file: {AWS_CREDENTIALS_PATH}")
         except Exception as e:
             logger.exception('Error updating credentials file!')
             return self._resp(http.HTTPStatus.INTERNAL_SERVER_ERROR, f'{type(e).__name__}: {e}')
+
+        # Update .env files if specified (don't fail the request if this errors)
+        if env_paths:
+            logger.info(f"Processing {len(env_paths)} .env file paths...")
+            try:
+                update_env_files(credentials)
+                logger.info("Finished updating .env files")
+            except Exception as e:
+                logger.exception('Error updating .env files!')
+                # Don't return error - we still want to report success for credentials file
+        else:
+            logger.info("No env_file_paths specified, skipping .env file updates")
 
         return self._resp(http.HTTPStatus.OK, 'ok')
 

--- a/extension/background.js
+++ b/extension/background.js
@@ -251,6 +251,22 @@ function fetchSts(roleArn, principalArn, samlResponse, props, port) {
 				credobj[`${matches[1]}`] = matches[2];
 			}
 			if (props.clientupdate) {
+				// Add env_file_paths to credobj if specified
+				if (props.env_file_paths) {
+					const paths = props.env_file_paths
+						.split("\n")
+						.map((p) => p.trim())
+						.filter((p) => p.length > 0)
+						.map((p) => {
+							// Remove trailing slash if present
+							p = p.replace(/\/$/, '');
+							// If already ends with .env, use as-is; otherwise append /.env
+							return p.endsWith(".env") ? p : `${p}/.env`;
+						});
+					if (paths.length > 0) {
+						credobj.env_file_paths = paths;
+					}
+				}
 				fetch("http://localhost:31339/update", {
 					method: "POST",
 					headers: {

--- a/extension/defaults.js
+++ b/extension/defaults.js
@@ -10,6 +10,7 @@ const defaults = {
 	platform: getPlatform(),
 	clientupdate: true,
 	idp_type: "google",
+	env_file_paths: "",
 };
 
 function getPlatform() {

--- a/extension/options.html
+++ b/extension/options.html
@@ -23,7 +23,12 @@
             </div>
             <div class="item">
                 <input type="text" id="google_spid" placeholder="Google Service Provider ID" class="txtbox" />
-                <label for=google_spid">Google Service Provider ID</label>
+                <label for="google_spid">Google Service Provider ID</label>
+            </div>
+            <div class="item">
+                <textarea id="env_file_paths" placeholder="/path/to/project1
+/path/to/project2" class="txtbox" rows="4"></textarea>
+                <label for="env_file_paths">Project directories to auto-update (one per line). A .env file will be created/updated in each directory with AWS credentials.</label>
             </div>
             <button>Save</button>
         </div>

--- a/extension/options.js
+++ b/extension/options.js
@@ -39,7 +39,7 @@ $("select").change(function () {
 
 function loadOptions() {
 	storage.get(
-		["saml_provider", "organization_domain", "google_idpid", "google_spid"],
+		["saml_provider", "organization_domain", "google_idpid", "google_spid", "env_file_paths"],
 		(props) => {
 			$(".txtbox").each(function () {
 				$(this).val(props[$(this).prop("id")]);


### PR DESCRIPTION
## Summary
Adds support for automatically updating specified .env files with fresh AWS credentials whenever tokens are refreshed. This eliminates the manual step of copying credentials from the extension to project .env files.

## Changes
- **Extension Options**: Added textarea to specify project directories (one per line)
- **Auto .env suffix**: Paths automatically get `/.env` appended if not already present
- **Python Service**: Added `update_env_files()` to write `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_SESSION_TOKEN` to specified .env files
- **Format preservation**: Maintains existing `export` prefix format if present
- **Logging**: Added server-side logging for debugging

## Usage
1. Open extension Options
2. Add project directories in the "Paths to .env files" field:
3. 
<img width="414" height="567" alt="Screenshot 2026-03-18 at 17 13 57" src="https://github.com/user-attachments/assets/7270a857-347f-42c5-9946-347398fcb40e" />



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new behavior that writes AWS credentials into user-specified `.env` files via the local updater service; incorrect paths or formatting edge cases could overwrite configuration files or leak credentials into unintended locations.
> 
> **Overview**
> Adds an optional workflow to propagate refreshed STS credentials into project `.env` files in addition to updating `~/.aws/credentials`.
> 
> The extension now exposes an `env_file_paths` option (multi-line textarea), normalizes entries to per-project `.env` file paths, and includes them in the localhost `/update` payload when `clientupdate` is enabled. The macOS Python updater service consumes `env_file_paths` and creates/updates each `.env` file with `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_SESSION_TOKEN` (preserving `export` prefixes where present), with extra logging and best-effort error handling. README docs are updated to describe the new option.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit abf4ff16dff708e021ab858c88f475f1c138b707. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->