### PR TITLE
feat: support named profiles

### DIFF
--- a/aosvc-python/aosvc
+++ b/aosvc-python/aosvc
@@ -55,14 +55,25 @@ class MyRequestHandler(http.server.BaseHTTPRequestHandler):
             return self._resp(http.HTTPStatus.BAD_REQUEST, f'{type(e).__name__}: {e}')
 
         try:
+            profile_name = credentials.get('ProfileName')
+
             # The default_section argument makes sure we have the section even if it's not in the file (or there is no file)
             ini = configparser.ConfigParser(default_section='default')
             ini.read(AWS_CREDENTIALS_PATH)
-            section = ini['default']
-            section['aws_access_key_id'] = credentials['AccessKeyId']
-            section['aws_secret_access_key'] = credentials['SecretAccessKey']
-            section['aws_session_token'] = credentials['SessionToken']
-            section['aws_session_expiration'] = credentials['Expiration']
+
+            def write_section(section):
+                section['aws_access_key_id'] = credentials['AccessKeyId']
+                section['aws_secret_access_key'] = credentials['SecretAccessKey']
+                section['aws_session_token'] = credentials['SessionToken']
+                section['aws_session_expiration'] = credentials['Expiration']
+
+            write_section(ini['default'])
+
+            if profile_name:
+                if profile_name not in ini:
+                    ini[profile_name] = {}
+                write_section(ini[profile_name])
+
             with AWS_CREDENTIALS_PATH.open('w') as f:
                 ini.write(f, space_around_delimiters=False)
         except Exception as e:

--- a/aosvc/main.go
+++ b/aosvc/main.go
@@ -32,10 +32,11 @@ type program struct {
 }
 
 type Credentials struct {
-    AccessKeyId string
+    AccessKeyId     string
 	SecretAccessKey string
-	SessionToken string
-	Expiration string
+	SessionToken    string
+	Expiration      string
+	ProfileName     string
 }
 
 func main() {
@@ -126,6 +127,15 @@ func (p *program) updateCredFile(creds Credentials) error {
 	cfg.Section("default").Key("aws_secret_access_key").SetValue(creds.SecretAccessKey)
 	cfg.Section("default").Key("aws_session_token").SetValue(creds.SessionToken)
 	cfg.Section("default").Key("aws_session_expiration").SetValue(creds.Expiration)
+	log.Printf("updated default section")
+	if creds.ProfileName != "" {
+		cfg.DeleteSection(creds.ProfileName)
+		cfg.NewSection(creds.ProfileName)
+		cfg.Section(creds.ProfileName).Key("aws_access_key_id").SetValue(creds.AccessKeyId)
+		cfg.Section(creds.ProfileName).Key("aws_secret_access_key").SetValue(creds.SecretAccessKey)
+		cfg.Section(creds.ProfileName).Key("aws_session_token").SetValue(creds.SessionToken)
+		cfg.Section(creds.ProfileName).Key("aws_session_expiration").SetValue(creds.Expiration)
+	}
 	cfg.SaveTo(filePath+"credentials")
 	log.Printf("updated %vcredentials file", filePath)
 	return nil

--- a/extension/background.js
+++ b/extension/background.js
@@ -235,6 +235,7 @@ function refreshAwsTokensAndStsCredentials(props, port, samlResponse) {
   const roleArn = arnPrefix + role;
   const awsAccount = roleArn.split(":")[4];
   const principalArn = `${arnPrefix}${awsAccount}:saml-provider/${props.saml_provider}`;
+  const accountName = ((props.accountNames || {})[awsAccount] || '').replace(/\s*\(\d+\)\s*$/, '') || undefined;
   const data = `RelayState=&SAMLResponse=${encodeURIComponent(samlResponse)}&name=&portal=&roleIndex=${encodeURIComponent(roleArn)}`;
   fetch(awsSamlUrl, {
     method: "POST",
@@ -250,7 +251,7 @@ function refreshAwsTokensAndStsCredentials(props, port, samlResponse) {
       }
       const date = new Date().toLocaleString();
       console.log(`AWS AlwaysON refreshed tokens successfuly at ${date}`);
-      fetchSts(roleArn, principalArn, samlResponse, props, port);
+      fetchSts(roleArn, principalArn, samlResponse, props, port, accountName);
     })
     .catch((error) => {
       const msg = `Error in SAML fetch:${error}`;
@@ -343,7 +344,7 @@ async function awsInit(props, port = null, jobType = "refresh") {
   }
 }
 
-function fetchSts(roleArn, principalArn, samlResponse, props, port) {
+function fetchSts(roleArn, principalArn, samlResponse, props, port, profileName) {
   const formBody = new URLSearchParams({
     Version: "2011-06-15",
     Action: "AssumeRoleWithSAML",
@@ -371,6 +372,7 @@ function fetchSts(roleArn, principalArn, samlResponse, props, port) {
         storage.set({ [`aws${matches[1]}`]: matches[2] });
         credobj[`${matches[1]}`] = matches[2];
       }
+      if (profileName) credobj['ProfileName'] = profileName;
       if (props.clientupdate) {
         fetch("http://localhost:31339/update", {
           method: "POST",


### PR DESCRIPTION
This change adds support to save the credentials to named profiles. A use case for this is to allow developers to work on multiple separate repositories that use different AWS accounts by adopting the named profiles upon devenv or in frameworks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds optional `ProfileName` handling end-to-end and changes how local AWS credentials files are written, which could overwrite or create additional INI sections if mis-specified.
> 
> **Overview**
> Adds support for persisting refreshed AWS STS credentials to an *optional named profile* in `~/.aws/credentials`, while still updating `default`.
> 
> The browser extension now derives a profile name from the AWS account label and includes it as `ProfileName` when posting credentials to the local update service. Both the Python and Go credential writers accept this field and, when present, create/overwrite the corresponding INI section with the same keys written to `default`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5f8f0862bc003b1c8b141fbab25d155ea3fd85c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->