### PR TITLE
fix(aosvc-python): create ~/Library/LaunchAgents if missing in mac installer

### DIFF
--- a/aosvc-python/install_mac.sh
+++ b/aosvc-python/install_mac.sh
@@ -7,6 +7,7 @@ service_path="$HOME/.local/share/aosvc/bin"
 user_uid=$(id -u)
 
 mkdir -p "$service_path"
+mkdir -p "$launch_config_dir"
 cp aosvc "$service_path"
 cp aosvc.plist "$launch_config_path"
 launchctl bootstrap "gui/$user_uid" "$launch_config_path"


### PR DESCRIPTION
## Summary
- `install_mac.sh` assumed `~/Library/LaunchAgents` already exists and only `mkdir -p`'d the binary install path, not the LaunchAgents directory.
- On a Mac that has never had any per-user launchd agent installed, that directory doesn't exist, so `cp aosvc.plist ...` fails with "No such file or directory" and the install aborts.
- Adds `mkdir -p "$launch_config_dir"` before the plist is copied.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line installer change with no runtime, auth, or data-handling impact.
> 
> **Overview**
> **Fixes Mac installs on machines that never had a user LaunchAgent**, where `cp aosvc.plist` into `~/Library/LaunchAgents` failed because only the binary path was created with `mkdir -p`.
> 
> Adds `mkdir -p "$launch_config_dir"` immediately before the plist copy, matching the existing pattern used for `service_path`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1cb16da7f60abc160bab6f8264eee79ffe95ea0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->