### PR TITLE
chore: prevent webblockrequests on mv3

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -36,6 +36,14 @@ function getApi() {
   return undefined;
 }
 
+function supportsBlockingWebRequest(api) {
+  try {
+    return api?.runtime?.getManifest?.().manifest_version <= 2;
+  } catch (e) {
+    return false;
+  }
+}
+
 // Cookie injection state
 let activeCookieStoreId = null;
 let pendingCookies = new Map(); // Map of URL -> cookie header string
@@ -44,7 +52,8 @@ let pendingCookies = new Map(); // Map of URL -> cookie header string
 const api = getApi();
 const canInjectCookies =
   api?.webRequest?.onBeforeSendHeaders &&
-  typeof api.webRequest.onBeforeSendHeaders.addListener === "function";
+  typeof api.webRequest.onBeforeSendHeaders.addListener === "function" &&
+  supportsBlockingWebRequest(api);
 
 if (canInjectCookies) {
   api.webRequest.onBeforeSendHeaders.addListener(

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -11,7 +11,7 @@
     "48": "img/icon48.png",
     "128": "img/icon128.png"
   },
-  "permissions": ["webRequest", "webRequestBlocking", "storage", "alarms"],
+  "permissions": ["webRequest", "storage", "alarms"],
   "host_permissions": [
     "https://accounts.google.com/*",
     "https://signin.aws.amazon.com/*",


### PR DESCRIPTION
MV2 is no longer supported and thus as well WebBlockingRequests for newer chrome installations.

<img width="1932" height="846" alt="image" src="https://github.com/user-attachments/assets/5b2ec441-b2e3-4957-9e47-89d443e60868" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> MV3 Chrome users lose container-based cookie injection for Google SSO flows; core non-container paths are unchanged but multi-account/container workflows may break.
> 
> **Overview**
> Aligns the Chrome **Manifest V3** build with platform rules by dropping the invalid **`webRequestBlocking`** permission and only registering the blocking **`onBeforeSendHeaders`** cookie-injection listener when the manifest is **MV2 or lower**.
> 
> On **MV3** (this repo’s `manifest.json`), **`canInjectCookies`** is now false, so the extension skips blocking header mutation and keeps the existing console warning that **container cookie injection is disabled**—avoiding runtime/API errors from unsupported blocking webRequest on current Chrome.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b816ab6185d91a5e1b3e55f4f8e7fda9712d0bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->