### PR TITLE
chore: add faq section for newcomers

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,3 +75,10 @@ netstat
 3. `./install_mac.sh`
 
 More info [here](/aosvc-python/README.md).
+
+## FAQ
+**Question:** Why can't I see the roles?
+
+> **Answer:** The extension only shows AWS roles that are assigned to your Google Workspace account via SSO. If you see no roles (or fewer than expected), your account may not yet be in the right Google groups — for example, the `developer` group.
+>
+> Access to specific AWS accounts (e.g. Studeersnel, DataEngineering) depends on being in the corresponding groups/roles. Ask your team lead or IT to confirm your group memberships if you’re missing access.


### PR DESCRIPTION
In some cases the newcomers setup their AWS extension and see no roles, this FAQ hopefully helps them understand what needs to be done in order to see roles.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no code or runtime impact.
> 
> **Overview**
> Adds a **FAQ** section to the root `README.md` explaining why the browser extension may show no AWS roles (or fewer than expected).
> 
> The entry clarifies that roles come from Google Workspace SSO group assignments (e.g. `developer`) and that account-specific access depends on the right groups, with a pointer to team lead or IT for membership checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85b637fa986f2b935ec4c9b9acc37ed038ee094e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->