### PR TITLE
fix(aosvc-python): make mac install script idempotent

### DIFF
--- a/aosvc-python/install_mac.sh
+++ b/aosvc-python/install_mac.sh
@@ -10,5 +10,6 @@ mkdir -p "$service_path"
 mkdir -p "$launch_config_dir"
 cp aosvc "$service_path"
 cp aosvc.plist "$launch_config_path"
+launchctl bootout "gui/$user_uid/aosvc" 2>/dev/null || true
 launchctl bootstrap "gui/$user_uid" "$launch_config_path"
 launchctl start aosvc


### PR DESCRIPTION
## Summary
- `launchctl bootstrap` fails with `Bootstrap failed: 5: Input/output error` when a job with the same label (`aosvc`) is already loaded, so re-running `install_mac.sh` after the service was already installed/running always failed.
- Add a `launchctl bootout` before `bootstrap` (ignoring failure if nothing was loaded) so the installer can be run repeatedly.

## Test plan
- [x] Ran `install_mac.sh` on a machine where `aosvc` was already running — previously failed with `Bootstrap failed: 5: Input/output error`, now succeeds and restarts the service cleanly.
- [x] Ran it twice in a row to confirm idempotency; `launchctl list | grep aosvc` shows the service running after each run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line installer change with no auth, data, or runtime logic impact beyond making reinstall safe.
> 
> **Overview**
> **Mac install** now unloads any existing `aosvc` launchd job before `launchctl bootstrap`, so re-running `install_mac.sh` no longer hits `Bootstrap failed: 5` when the service is already loaded.
> 
> `launchctl bootout "gui/$user_uid/aosvc"` runs with errors suppressed (`2>/dev/null || true`) when nothing is loaded; bootstrap and start then proceed as before.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bfb23557d3748118fb676720689931d65504ed2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->